### PR TITLE
(SIMP-4364) Support UEFI PXEboot

### DIFF
--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -4,7 +4,7 @@
 
 Summary: SIMP rsync repository
 Name: simp-rsync
-Version: 6.2.0
+Version: 6.2.1
 Release: 0%{?dist}
 License: Apache License, Version 2.0 and ISC
 Group: Applications/System
@@ -110,6 +110,10 @@ fi
 %postun
 # Post uninstall stuff
 %changelog
+* Thu Apr 26 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.1-0
+- Added logic in dhcpd.conf to select the appropriate PXEboot file
+  based on the boot type (BIOS or UEFI).
+
 * Thu Oct 26 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.0-0
 - The selinux policy in simp-environment was changing settings on rsync
   files not in the simp environment.  If DNS and DHCP were running in an

--- a/environments/simp/rsync/RedHat/Global/dhcpd/dhcpd.conf
+++ b/environments/simp/rsync/RedHat/Global/dhcpd/dhcpd.conf
@@ -2,10 +2,29 @@ allow booting;
 allow bootp;
 ddns-update-style interim;
 
+option space pxelinux;
+option pxelinux.magic code 208 = string;
+option pxelinux.configfile code 209 = text;
+option pxelinux.pathprefix code 210 = text;
+option pxelinux.reboottime code 211 = unsigned integer 32;
+option architecture-type code 93 = unsigned integer 16;
+
 class "pxeclients" {
   match if substring(option vendor-class-identifier, 0, 9) = "PXEClient";
   next-server 				10.0.0.2;
-  filename				"linux-install/pxelinux.0";
+
+  # The appropriate value to use for the default UEFI PXEboot file
+  # below depends upon the OS and whether secure boot is enabled:
+  #   CentOS 7 (grub2) normal UEFI boot       -->  "linux-install/efi/grubx64.efi";
+  #   CentOS 7 (grub2) secure UEFI boot       -->  "linux-install/efi/shim.efi";
+  #   CentOS 6 (legacy grub) normal UEFI boot -->  "linux-install/efi/grub.efi";
+  #   (There is no CentOS 6 support for secure boot)
+  #
+  if option architecture-type = 00:07 {
+    filename    "linux-install/efi/grubx64.efi";
+  } else {
+    filename    "linux-install/pxelinux.0";
+  }
 }
 
 subnet 10.0.0.0 netmask 255.255.255.0 {


### PR DESCRIPTION
Added logic in dhcpd.conf to select the appropriate PXEboot file
based on the boot type (BIOS or UEFI).

NOTE:
* Even though the new dhcpd.conf configuration was pulled from the
  RedHat 7 installation guide and differs from the suggested
  configuration in the RedHat 6 installation guide, this configuration
  it has been verified to work on CentOS 6.
* This PR intentionally does not break out distinct dhcpd.conf files
  for CentOS/RedHat 6 and 7. We decided that split was not worth doing
  at this time, given:
  (1) dhcpd.conf has to be edited by the user to be useful.
  (2) Such a change would break the current version of pupmod-simp-dhcp.

  We can revisit this issue when CentOS/RedHat 8 is released.

SIMP-4364 #comment simp-environment-skeleton updates