### PR TITLE
(SIMP-6606) Fix Update to 6.4

### DIFF
--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -111,7 +111,7 @@ fi
 %changelog
 * Tue May 21 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.1-2
 - Remove dependency for simp-environment-selinux-policy.  It has been moved
-  to simp-environment.  It caused a confilict when upgrading.
+  to simp-environment.  It caused a conflict when upgrading.
  
 * Tue May 14 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.1-1
 - Remove dependency on simp-environment, which will be removed in

--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -12,7 +12,6 @@ Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: rsync
 Requires: acl
-Requires: simp-environment-selinux-policy
 
 Provides: simp_rsync_filestore = %{version}
 Obsoletes: simp_rsync_filestore >= 1.0.0
@@ -110,6 +109,10 @@ fi
 %postun
 # Post uninstall stuff
 %changelog
+* Tue May 21 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.1-2
+- Remove dependency for simp-environment-selinux-policy.  It has been moved
+  to simp-environment.  It caused a confilict when upgrading.
+ 
 * Tue May 14 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.1-1
 - Remove dependency on simp-environment, which will be removed in
   SIMP 6.4 and renamed to simp-environment-skeleton

--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -5,7 +5,7 @@
 Summary: SIMP rsync repository
 Name: simp-rsync
 Version: 6.2.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: Apache License, Version 2.0 and ISC
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz


### PR DESCRIPTION
- removed dependency on simp-environment-selinux-policy.  It caused an
  error when updating to 6.4.  The policy is installed by
  simp-environment.

SIMP-6606 #comment has companion PR for simp-environment.