### PR TITLE
Remove rndc.key from repository

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 13 2019 Robert Clark <rbclark@mitre.org> - 7.0.2-0
+- Removed rndc.key from repository to prevent users from accidentally using
+  a published secret key.
+
 * Wed May 22 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.1-0
 - Removed OBE *.rpmnew deletion logic in %post
 - Removed OBE OS symlink login in %post and %preun
@@ -257,4 +261,3 @@
 
 * Thu Oct 01 2009 Maintenance 0.1-11
 - Fixed /etc/postfix directory permissions
-

--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -24,7 +24,7 @@ end
 
 Summary: SIMP rsync skeleton
 Name: simp-rsync-skeleton
-Version: 7.0.1
+Version: 7.0.2
 Release: 0
 License: Apache License, Version 2.0 and ISC
 Group: Applications/System

--- a/rsync/RedHat/7/bind_dns/default/named/etc/rndc.key
+++ b/rsync/RedHat/7/bind_dns/default/named/etc/rndc.key
@@ -1,4 +1,0 @@
-key "rndckey" {
-	algorithm	hmac-md5;
-	secret		"hBYefYTxvLwfuKDG6qX7oKv3O23dWMtGYWx7evCurYZzXskdRSko1CvgGY9f";
-};


### PR DESCRIPTION
This is to avoid users mistaking this as a properly generated secret and using it in their environment.

There are a few alternatives here as well and I can put whichever one is preferred up as a pull request in place of this one. Another option is to simply remove the `secret` line, and if users run `rndc-confgen -a -c /var/simp/environments/simp/rsync/RedHat/7/bind_dns/default/named/etc/rndc.key` a properly generated secret will be added to the file. One issue with this is the default algorithm no longer works on RedHat, it would need to be changed to `hmac-sha256`.