### PR TITLE
(SIMP-7237) Remove RNDC.key from rsync

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Nov 19 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.2-0
+- Removed rndc.key from RedHat 6
+- Update rsync.facl file.
+
 * Fri Sep 13 2019 Robert Clark <rbclark@mitre.org> - 7.0.2-0
 - Removed rndc.key from repository to prevent users from accidentally using
   a published secret key.

--- a/rsync/.rsync.facl
+++ b/rsync/.rsync.facl
@@ -397,13 +397,6 @@ user::rw-
 group::r--
 other::---
 
-# file: RedHat/6/bind_dns/default/named/etc/rndc.key
-# owner: root
-# group: 25
-user::rw-
-group::r--
-other::---
-
 # file: RedHat/6/bind_dns/default/named/etc/named.conf
 # owner: root
 # group: 25
@@ -608,13 +601,6 @@ group::r-x
 other::---
 
 # file: RedHat/7/bind_dns/default/named/etc/zones/your.domain
-# owner: root
-# group: 25
-user::rw-
-group::r--
-other::---
-
-# file: RedHat/7/bind_dns/default/named/etc/rndc.key
 # owner: root
 # group: 25
 user::rw-

--- a/rsync/RedHat/6/bind_dns/default/named/etc/rndc.key
+++ b/rsync/RedHat/6/bind_dns/default/named/etc/rndc.key
@@ -1,4 +1,0 @@
-key "rndckey" {
-	algorithm	hmac-md5;
-	secret		"hBYefYT8vLwfxKDF6qX7oKv3O23dWMtGYWx7evCurYZzXskdRSko1CvgGY9f";
-};


### PR DESCRIPTION
- Remove the rndc.key from rsync.  The service will
  create a key if one does not exist using the correct defaults
  for the system.
- Update the rsync.facl file

SIMP-7237 #close