### PR TITLE
(SIMP-8396) Sample named.conf has wrong name for rndc key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Sep 23 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.3-0
+- Fixed a bug in which the name of the rndc key in the sample named.conf
+  files did not match the name of the automatically-generated key in
+  /etc/rndc.key. This mismatch would prevent the named service from starting.
+
 * Tue Dec 17 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 7.0.2-0
 - Added mitigation for CVE-2019-6477 to RedHat 7 named.conf 
 

--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -24,7 +24,7 @@ end
 
 Summary: SIMP rsync skeleton
 Name: simp-rsync-skeleton
-Version: 7.0.2
+Version: 7.0.3
 Release: 0
 License: Apache License, Version 2.0 and ISC
 Group: Applications/System

--- a/rsync/RedHat/6/bind_dns/default/named/etc/named.conf
+++ b/rsync/RedHat/6/bind_dns/default/named/etc/named.conf
@@ -67,7 +67,7 @@ logging
 include "/etc/rndc.key";
 
 controls {
-  inet 127.0.0.1 allow { localhost; } keys { rndckey; };
+  inet 127.0.0.1 allow { localhost; } keys { rndc-key; };
 };
 
 zone "localdomain" IN {

--- a/rsync/RedHat/7/bind_dns/default/named/etc/named.conf
+++ b/rsync/RedHat/7/bind_dns/default/named/etc/named.conf
@@ -73,7 +73,7 @@ logging
 include "/etc/rndc.key";
 
 controls {
-  inet 127.0.0.1 allow { localhost; } keys { rndckey; };
+  inet 127.0.0.1 allow { localhost; } keys { rndc-key; };
 };
 
 zone "localdomain" IN {


### PR DESCRIPTION
Fixed a bug in which the name of the rndc key in the sample named.conf
files did not match the name of the automatically-generated key in
/etc/rndc.key. This mismatch would prevent the named service from
starting.

SIMP-8396 #close